### PR TITLE
added `set commentstring` line in plugin/mason.vim

### DIFF
--- a/plugin/mason.vim
+++ b/plugin/mason.vim
@@ -1,0 +1,1 @@
+autocmd FileType mason set commentstring=#\ %s

--- a/plugin/mason.vim
+++ b/plugin/mason.vim
@@ -1,1 +1,1 @@
-autocmd FileType mason set commentstring=#\ %s
+autocmd FileType mason setlocal commentstring=#\ %s


### PR DESCRIPTION
&hellip;so plugins like [vim-commentary](https://github.com/tpope/vim-commentary) work.
